### PR TITLE
Fixed javascript path construction

### DIFF
--- a/django_simple_bulma/templatetags/django_simple_bulma.py
+++ b/django_simple_bulma/templatetags/django_simple_bulma.py
@@ -30,7 +30,7 @@ def bulma():
 
     # Build html to include all the js files required.
     for filename in js_folder.iterdir():
-        js_file = static(f"js/{filename}")
+        js_file = static(f"js/{filename.name}")
         extension_name = filename.stem
 
         if extension_name in extensions or extensions == "_all":


### PR DESCRIPTION
This fixes `js_file` path construction in templates.
Uses filename instead of full path.

I tested this by using my fork in my own project and all `js` files downloaded correctly after `collectstatic` command.