### PR TITLE
bulma-navbar-burger

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Additional scripts
 For your convenience, we also give you the option to add other quality of life improvements to your Bulma app. If you are not specifying any extensions in `BULMA_SETTINGS`, these will all be loaded by default. If you are, you may want to add these as well if they sound useful to you.
 
 * `bulma-fileupload` will handle displaying the filename in your [file upload inputs](https://bulma.io/documentation/form/file/).
+* `bulma-navbar-burger` will hook up your `navbar-burger`s and `navbar-menu`s automatically, to provide a toggle for mobile users. We use a slightly updated version of [the example from Bulma's documentation](https://bulma.io/documentation/components/navbar/#navbarJsExample) - simply add a `data-target` attribute to your `navbar-burger` that refers to the `id` of the `navbar-menu` that should be expanded and collapsed by the button.
 * `bulma-notifications` will allow you to close [notifications](https://bulma.io/documentation/elements/notification/) by clicking on the X button.
 
 Troubleshooting

--- a/django_simple_bulma/js/bulma-navbar-burger.js
+++ b/django_simple_bulma/js/bulma-navbar-burger.js
@@ -1,0 +1,34 @@
+/*****
+ * A DOMContentLoaded event listener for use with Bulma that connects the "click" event of each
+ * navbar-burger element with the navbar-menu referred to by ID in the "data-target" attribute.
+ *
+ * This file is a slightly modified version of the example found in the Bulma documentation for
+ * the navbar component. It's been updated for some of the newer Javascript standards, but will
+ * otherwise behave in exactly the same way.
+ *
+ * Bulma documentation page: https://bulma.io/documentation/components/navbar/#navbarJsExample
+ *****/
+
+document.addEventListener('DOMContentLoaded', () => {
+
+  // Get all "navbar-burger" elements
+  const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+
+  // Check if there are any navbar burgers
+  if ($navbarBurgers.length > 0) {
+
+    // Add a click event on each of them
+    $navbarBurgers.forEach($el => {
+      $el.addEventListener('click', function () {
+
+        // Get the target from the "data-target" attribute
+        const target = $el.dataset.target;
+        const $target = document.getElementById(target);
+
+        // Toggle the class on both the "navbar-burger" and the "navbar-menu"
+        $el.classList.toggle('is-active');
+        $target.classList.toggle('is-active');
+      });
+    });
+  }
+});

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="django-simple-bulma",
-    version="1.1.5",
+    version="1.1.6",
     description="Django application to add the Bulma CSS framework and its extensions",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This pull request adds `bulma-navbar-burger.js`, an addition to `README.md` to go with it, and a version bump to `1.1.6`.

This JavaScript file serves to hook up your `navbar-burger`s to their respective `navbar-menu`s by ID, via a `data-target` attribute on the burger element. For example:

```html
<nav class="navbar" role="navigation" aria-label="main navigation">
    <div class="navbar-brand">
        <a class="navbar-item" href="/">
            Home
        </a>
        <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbar_menu">
            <span aria-hidden="true"></span>
            <span aria-hidden="true"></span>
            <span aria-hidden="true"></span>
        </a>
    </div>
    <div class="navbar-menu" id="navbar_menu">
        <a class="navbar-item" href="/blog">
            Blog
        </a>
    </div>
</nav>
```

This will result in the following on mobile:

![image](https://user-images.githubusercontent.com/204153/52645038-e2d58080-2ed7-11e9-8037-d9b29b4457ba.png)

When clicked, this will expand the menu downwards:

![image](https://user-images.githubusercontent.com/204153/52645073-f254c980-2ed7-11e9-960f-703f057138d8.png)

---

This script is a modified version of an example script provided in [the Bulma documentation](https://bulma.io/documentation/components/navbar/#navbarJsExample) - I modified it in order to update the Javascript within to a newer standard, making use of arrow functions and `const` instead of `var`. Otherwise, it behaves in exactly the same way.

This script has been tested in **Firefox 65.0** and **Chromium 72.0.3626.96**.