### PR TITLE
Update pre-commit config so it actually uses the flake8 plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 
 build/
 dist/
-crispy_bulma.egg-info/
+django_simple_bulma.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.2.3
     hooks:
     - id: flake8
+      additional_dependencies: [
+        "flake8-bugbear",
+        "flake8-import-order",
+        "flake8-tidy-imports",
+        "flake8-todo",
+        "flake8-type-annotations",
+        "flake8-string-format"
+      ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,10 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: [
-        "flake8-bugbear",
-        "flake8-import-order",
-        "flake8-tidy-imports",
-        "flake8-todo",
-        "flake8-type-annotations",
-        "flake8-string-format"
+        "flake8-bugbear~=19.8",
+        "flake8-import-order~=0.18",
+        "flake8-tidy-imports~=2.0",
+        "flake8-todo~=0.7",
+        "flake8-type-annotations~=0.1",
+        "flake8-string-format~=0.2"
       ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,5 @@ repos:
         "flake8-import-order~=0.18",
         "flake8-tidy-imports~=2.0",
         "flake8-todo~=0.7",
-        "flake8-type-annotations~=0.1",
         "flake8-string-format~=0.2"
       ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Note that contributions may be rejected on the basis of a contributor failing to
 1. **No force-pushes** or modifying the Git history in any way.
 2. If you have direct access to the repository, **create a branch for your changes** and create a pull request for that branch. If not, create a branch on a fork of the repository and create a pull request from there.
     * It's common practice for a repository to reject direct pushes to `master`, so make branching a habit!
+    * If PRing from your own fork, **ensure that "Allow edits from maintainers" is checked**. This gives permission for maintainers to commit changes directly to your fork, speeding up the review process.
 3. **Adhere to the prevailing code style**, which we enforce using [flake8](http://flake8.pycqa.org/en/latest/index.html).
     * Run `flake8` against your code **before** you push it. Your commit will be rejected by the build server if it fails to lint.
     * [Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) are a powerful tool that can be a daunting to set up. Fortunately, [`pre-commit`](https://github.com/pre-commit/pre-commit) abstracts this process away from you and is provided as a dev dependency for this project. Run `pipenv run precommit` when setting up the project and you'll never have to worry about breaking the build for linting errors.
@@ -78,6 +79,13 @@ def foo(bar: int, baz: dict=None) -> bool:
     This function takes an index, `bar` and checks for its presence in the database `baz`, passed as a dictionary. Returns `False` if `baz` is not passed.
     """
 ```
+
+### Work in Progress (WIP) PRs
+Github [has introduced a new PR feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/) that allows the PR author to mark it as a WIP. This provides both a visual and functional indicator that the contents of the PR are in a draft state and not yet ready for formal review.
+
+This feature should be utilized in place of the traditional method of prepending `[WIP]` to the PR title.
+
+As stated earlier, **ensure that "Allow edits from maintainers" is checked**. This gives permission for maintainers to commit changes directly to your fork, speeding up the review process.
 
 ## Footnotes
 


### PR DESCRIPTION
Since pre-commit creates its own environment for linting, additional flake8 plugins need to be explicitly specified in order to be used.

This also updates the contrib doc to align with recent changes (see: https://github.com/python-discord/organisation/issues/114)