### PR TITLE
Add output_style setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,17 @@ BULMA_SETTINGS = {
     "variables": {
         "primary": "#000000",
         "size-1": "6rem",
-    }
+    },
+    "output_style": "compressed"
 }
 ```
 
 You may here define any variable found on the [Bulma variables](https://bulma.io/documentation/customize/variables/) page, and you may use any valid SASS or CSS as the value. For example, `hsl(217, 71%, 53%)` would be a valid value for a color variable, as would `#ffff00`. Please note that any syntactically incorrect values may prevent Bulma from building correctly, so be careful what you add here unless you know exactly what you're doing.
 
 If the `extensions` key is not found, it will default to loading **all extensions**. If you don't want any extensions, simply set it to an empty list.
+
+The `output_style` determines the style of the resulting CSS file. It can be any of `"nested"` (default), `"expanded"`, `"compact"`, and `"compressed"`. It is recommended to use `"compressed"` in production as
+to reduce the final file size.
 
 Additional scripts
 ------------------

--- a/django_simple_bulma/finders.py
+++ b/django_simple_bulma/finders.py
@@ -33,6 +33,7 @@ class SimpleBulmaFinder(BaseFinder):
         self.custom_scss = self.bulma_settings.get("custom_scss", [])
         self.extensions = self.bulma_settings.get("extensions", "_all")
         self.variables = self.bulma_settings.get("variables", {})
+        self.output_style = self.bulma_settings.get("output_style", 'nested')
         self.storage = FileSystemStorage(self.simple_bulma_path)
 
     def _get_bulma_css(self):
@@ -62,7 +63,7 @@ class SimpleBulmaFinder(BaseFinder):
 
         # Store this as a css file
         if hasattr(sass, "libsass_version"):
-            css_string = sass.compile(string=scss_string)
+            css_string = sass.compile(string=scss_string, output_style=self.output_style)
         else:
             # If the user has the sass module installed in addition to libsass,
             # warn the user and fail hard.
@@ -109,7 +110,7 @@ class SimpleBulmaFinder(BaseFinder):
 
             # Store this as a css file - we don't check and raise here because it would have
             # already happened earlier, during the Bulma compilation
-            css_string = sass.compile(string=scss_string)
+            css_string = sass.compile(string=scss_string, output_style=self.output_style)
 
             css_path = self.simple_bulma_path / relative_path.parent
             css_path.mkdir(exist_ok=True)


### PR DESCRIPTION
This pr adds a new setting to the BULMA_SETTINGS dict.

`sass.compile(...)` takes an `output_style` kwarg that specifies how it generates CSS files. This pr adds a setting that takes advantage of this kwarg, meaning you can now generate a compressed (minified) bulma.css file.

If this setting is left untouched, it defaults to the same output_style as before this pr.