### PR TITLE
Add fontawesome_token option in BULMA_SETTINGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ BULMA_SETTINGS = {
         "primary": "#000000",
         "size-1": "6rem",
     },
-    "output_style": "compressed"
+    "output_style": "compressed",
+    "fontawesome_token": "e761a01be3",
 }
 ```
 
@@ -96,6 +97,8 @@ If an extension you want to use is missing, feel free to [create an issue](https
 
 The `output_style` determines the style of the resulting CSS file. It can be any of `"nested"` (default), `"expanded"`, `"compact"`, and `"compressed"`. It is recommended to use `"compressed"` in production as
 to reduce the final file size.
+
+Your `fontawesome_token` is the identifier part of your FontAwesome kit src <code><a>https://kit.fontawesome.com/<u>e761a01be3</u>.js</a></code> (not your API token). If you leave out this option, FontAwesome v5.14.0 will be used instead.
 
 Additional scripts
 ------------------

--- a/django_simple_bulma/templatetags/django_simple_bulma.py
+++ b/django_simple_bulma/templatetags/django_simple_bulma.py
@@ -8,7 +8,10 @@ from django import template
 from django.templatetags.static import static
 from django.utils.safestring import SafeString, mark_safe
 
-from ..utils import get_js_files
+from ..utils import (
+    fontawesome_token,
+    get_js_files,
+)
 
 register = template.Library()
 
@@ -33,21 +36,32 @@ def bulma() -> SafeString:
 @register.simple_tag
 def font_awesome() -> SafeString:
     """
-    Return the latest FontAwesome CDN link.
+    Return the FontAwesome CDN link.
 
-    Currently just returns 5.6.3, but will
-    eventually return the latest version.
+    Returns whatever kit has been specified in BULMA_SETTINGS.
+    If none is provided, default to version 5.14.0
     """
-    cdn_link = (
-        '<link rel="preload" '
-        'href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" '
-        'integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" '
-        'crossorigin="anonymous" '
-        'as="style">\n'
-        '<link rel="stylesheet" '
-        'href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" '
-        'integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" '
-        'crossorigin="anonymous">'
-    )
+    if fontawesome_token:
+        cdn_link = (
+            '<link rel="preload" '
+            f'href="https://kit.fontawesome.com/{fontawesome_token}.js" '
+            'crossorigin="anonymous" '
+            'as="script">\n'
+            '<script defer '
+            f'src="https://kit.fontawesome.com/{fontawesome_token}.js" '
+            'crossorigin="anonymous"></script>'
+        )
+    else:
+        cdn_link = (
+            '<link rel="preload" '
+            'href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" '
+            'integrity="sha384-HzLeBuhoNPvSl5KYnjx0BT+WB0QEEqLprO+NBkkk5gbc67FTaL7XIGa2w1L0Xbgc" '
+            'crossorigin="anonymous" '
+            'as="style">\n'
+            '<link rel="stylesheet" '
+            'href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" '
+            'integrity="sha384-HzLeBuhoNPvSl5KYnjx0BT+WB0QEEqLprO+NBkkk5gbc67FTaL7XIGa2w1L0Xbgc" '
+            'crossorigin="anonymous">'
+        )
 
     return mark_safe(cdn_link)  # noqa

--- a/django_simple_bulma/utils.py
+++ b/django_simple_bulma/utils.py
@@ -9,8 +9,10 @@ from django.conf import settings
 # have been defined, default to all extensions.
 if hasattr(settings, "BULMA_SETTINGS"):
     extensions = settings.BULMA_SETTINGS.get("extensions", [])
+    fontawesome_token = settings.BULMA_SETTINGS.get("fontawesome_token", "")
 else:
     extensions = []
+    fontawesome_token = ""
 
 simple_bulma_path = Path(__file__).resolve().parent
 


### PR DESCRIPTION
Closes #54, and is one of the issues of #57. 

I also took the liberty of updating the default to the latest fontawesome version, which looks like it will be the last to be supported on their use.fontawesome.com cdn.

The FontAwesome Django plugin is coming mid-2020 according to their website. We might want to reevaluate how we handle this then. 