### PR TITLE
Add index.sass to sass_files_searches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
     steps:
     - name: Checkout the repo and the submodules.
       uses: actions/checkout@v2
-      with: 
+      with:
         submodules: recursive
-    
+
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: '3.x'
-        
+
     - name: Install build dependencies & build
       run: |
         python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .idea
 .venv
+.vscode
 
 build/
 dist/*

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The optional `fontawesome_token` parameter allows you to specify your personal F
 ```
 Then your `fontawesome_token` should be **e761a01be3**.
 
-This is used by the `{% font_awesome %}` template tag to set up FontAwesome for you. If you don't specify a `fontawesome_token`, **the template tag will still work**, but will then use an older version of FontAwesome (v5.14.0). 
+This is used by the `{% font_awesome %}` template tag to set up FontAwesome for you. If you don't specify a `fontawesome_token`, **the template tag will still work**, but will then use an older version of FontAwesome (v5.14.0).
 
 Additional scripts
 ------------------

--- a/django_simple_bulma/utils.py
+++ b/django_simple_bulma/utils.py
@@ -17,8 +17,9 @@ else:
 simple_bulma_path = Path(__file__).resolve().parent
 
 # (Path, str) pairs describing a relative path in an extension and a glob pattern to search for
-sass_files_searchs = (
+sass_files_searches = (
     (Path("src/sass"), "_all.sass"),
+    (Path("src/sass"), "index.sass"),
     (Path("src/sass"), "*.sass"),
     (Path("src"), "*.s[ac]ss"),
     (Path("dist"), "*.sass"),
@@ -56,7 +57,7 @@ def get_js_files() -> Generator[str, None, None]:
 
 def get_sass_files(ext: Path) -> List[Path]:
     """Given the path to an extension, find and yield all files that should be imported"""
-    for rel_path, glob in sass_files_searchs:
+    for rel_path, glob in sass_files_searches:
         src_files = list((ext / rel_path).rglob(glob))
 
         for i, src in enumerate(src_files):


### PR DESCRIPTION
Some extensions use index.sass as an entry point instead of _all.sass.

This fixes a compilation error of bulma-tooltip I experienced in a docker container, but that I couldn't replicate outside of it.