### PR TITLE
Use DOMContentLoaded in bulma-dropdown.js

### DIFF
--- a/django_simple_bulma/extensions/bulma-dropdown/dist/js/bulma-dropdown.js
+++ b/django_simple_bulma/extensions/bulma-dropdown/dist/js/bulma-dropdown.js
@@ -1,4 +1,4 @@
-(function() {
+document.addEventListener('DOMContentLoaded', () => {
     function handle_event_wrapper(show, hide) {
         const handle_event = (e) => {
             if (show()) {
@@ -34,4 +34,4 @@
         element.addEventListener("click", handle_event_wrapper(show, hide));
         document.body.addEventListener("click", hide);
     }
-})();
+});


### PR DESCRIPTION
There was basically no guarantee that the dropdown element was loaded when the script ran. This was a leftover from the original script #27. Issue 27 also says you use that script on the PyDis site, so you should probably look into fixing it there too (unless the jQuery parts does some magic that defers the script execution/adding event listeners)